### PR TITLE
Fix audio distortion, improve DMA stability, and enhance mic quality

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,11 +45,7 @@ jobs:
 
       - name: Attach Kext To Release
         if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG_NAME="${{ github.event.release.tag_name }}"
-          if [ -z "$TAG_NAME" ]; then
-            TAG_NAME="${{ inputs.release_tag }}"
-          fi
-          gh release upload "$TAG_NAME" dist/AMDMicrophone.kext.zip --clobber
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.release.tag_name || inputs.release_tag }}
+          files: dist/AMDMicrophone.kext.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,26 +4,52 @@ on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag to attach the kext zip to"
+        required: false
+        type: string
   release:
     types: [published]
 
-env:
-  PROJECT_TYPE: KEXT
+permissions:
+  contents: write
 
 jobs:
   build:
-    name: Build
+    name: Build Kext
     runs-on: macos-latest
-    env:
-      JOB_TYPE: BUILD
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout Code
+        uses: actions/checkout@v4
         with:
           submodules: "recursive"
-      - run: xcodebuild -configuration Debug
-      - run: xcodebuild -configuration Release
-      - name: Upload to Artifacts
-        uses: actions/upload-artifact@v3
+
+      - name: Build Debug Version
+        run: xcodebuild -project AMDMicrophone.xcodeproj -scheme AMDMicrophone -configuration Debug SYMROOT=$PWD/build
+
+      - name: Build Release Version
+        run: xcodebuild -project AMDMicrophone.xcodeproj -scheme AMDMicrophone -configuration Release SYMROOT=$PWD/build
+
+      - name: Upload Kext Artifacts
+        uses: actions/upload-artifact@v4
         with:
-          name: Artifacts
+          name: AMDMicrophone-Kexts
           path: build/*/*.kext
+
+      - name: Package Release Kext
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+        run: |
+          mkdir -p dist
+          ditto -c -k --sequesterRsrc --keepParent build/Release/AMDMicrophone.kext dist/AMDMicrophone.kext.zip
+
+      - name: Attach Kext To Release
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && inputs.release_tag != '')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME="${{ github.event.release.tag_name }}"
+          if [ -z "$TAG_NAME" ]; then
+            TAG_NAME="${{ inputs.release_tag }}"
+          fi
+          gh release upload "$TAG_NAME" dist/AMDMicrophone.kext.zip --clobber

--- a/AMDMicrophone/AMDMicrophoneDevice.cpp
+++ b/AMDMicrophone/AMDMicrophoneDevice.cpp
@@ -41,15 +41,29 @@ void AMDMicrophoneDevice::configDMA()
         IOByteCount segmentLength = 0;
         addr64_t address = dmaDescriptor->getPhysicalSegment(offset, &segmentLength);
 
+        if (!address || !segmentLength)
+            break;
+
         low = (UInt32)address;
         high = (UInt32)(address >> 32);
 
         writel(low, ACP_SCRATCH_REG_0 + val);
         high |= BIT(31);
         writel(high, ACP_SCRATCH_REG_0 + val + 4);
-        offset += segmentLength;
+        offset += ACP_DMA_PAGE_SIZE;
         val += 8;
     }
+}
+
+void AMDMicrophoneDevice::clearDMABuffer()
+{
+    UInt8* buffer = (UInt8*)dmaDescriptor->getBytesNoCopy();
+
+    if (!buffer)
+        return;
+
+    for (UInt32 index = 0; index < BUFFER_SIZE; index++)
+        buffer[index] = 0;
 }
 
 void AMDMicrophoneDevice::disableInterrupt()
@@ -64,7 +78,8 @@ void AMDMicrophoneDevice::enableClock()
 
     writel(ACP_PDM_CLK_FREQ_MASK, ACP_WOV_CLK_CTRL);
     val = readl(ACP_WOV_MISC_CTRL);
-    val |= ACP_WOV_MISC_CTRL_MASK;
+    val &= ~ACP_WOV_GAIN_CONTROL;
+    val |= (ACP_WOV_PDM_GAIN << ACP_WOV_GAIN_CONTROL_SHIFT) & ACP_WOV_GAIN_CONTROL;
     writel(val, ACP_WOV_MISC_CTRL);
 }
 
@@ -82,6 +97,16 @@ UInt64 AMDMicrophoneDevice::getByteCount()
     low = readl(ACP_WOV_RX_LINEARPOSITIONCNTR_LOW);
 
     return ((UInt64)high << 32) | low;
+}
+
+UInt64 AMDMicrophoneDevice::getRelativeByteCount()
+{
+    UInt64 byteCount = getByteCount();
+
+    if (byteCount < dmaStartByteCount)
+        return 0;
+
+    return byteCount - dmaStartByteCount;
 }
 
 void AMDMicrophoneDevice::initRingBuffer(UInt32 physAddr, UInt32 bufferSize, UInt32 watermarkSize)
@@ -162,6 +187,7 @@ IOReturn AMDMicrophoneDevice::startDMA()
     UInt32 val;
     UInt32 timeout;
 
+    writel(0x1, ACP_WOV_PDM_FIFO_FLUSH);
     enableClock();
     writel(0x1, ACP_WOV_PDM_ENABLE);
     writel(0x1, ACP_WOV_PDM_DMA_ENABLE);
@@ -170,11 +196,16 @@ IOReturn AMDMicrophoneDevice::startDMA()
     while (++timeout < ACP_COUNTER) {
         val = readl(ACP_WOV_PDM_DMA_ENABLE);
         if ((val & 0x2) == ACP_PDM_DMA_EN_STATUS)
-            return kIOReturnSuccess;
+            break;
         IODelay(5);
     }
 
-    return kIOReturnTimeout;
+    if (timeout == ACP_COUNTER)
+        return kIOReturnTimeout;
+
+    dmaStartByteCount = getByteCount();
+    lastPeriodCount = 0;
+    return kIOReturnSuccess;
 }
 
 IOReturn AMDMicrophoneDevice::stopDMA()
@@ -254,7 +285,7 @@ void AMDMicrophoneDevice::interruptHandler()
     val = readl(ACP_EXTERNAL_INTR_STAT);
     if (val & BIT(ACP_PDM_DMA_STAT)) {
         writel(BIT(ACP_PDM_DMA_STAT), ACP_EXTERNAL_INTR_STAT);
-        byteCount = getByteCount();
+        byteCount = getRelativeByteCount();
         if (byteCount % BUFFER_SIZE == 0)
             audioEngine->takeTimeStamp();
     }
@@ -313,6 +344,10 @@ bool AMDMicrophoneDevice::initHardware(IOService* provider)
     dmaDescriptor = IOBufferMemoryDescriptor::inTaskWithOptions(kernel_task, kIODirectionIn, BUFFER_SIZE);
     if (!dmaDescriptor)
         goto Done;
+    if (dmaDescriptor->prepare(kIODirectionIn) != kIOReturnSuccess)
+        goto Done;
+    dmaPrepared = true;
+    clearDMABuffer();
 
     workLoop = getWorkLoop();
     if (!workLoop)
@@ -370,6 +405,10 @@ void AMDMicrophoneDevice::free()
     }
 
     if (dmaDescriptor) {
+        if (dmaPrepared) {
+            dmaDescriptor->complete(kIODirectionIn);
+            dmaPrepared = false;
+        }
         dmaDescriptor->release();
         dmaDescriptor = NULL;
     }

--- a/AMDMicrophone/AMDMicrophoneDevice.hpp
+++ b/AMDMicrophone/AMDMicrophoneDevice.hpp
@@ -44,9 +44,12 @@
 #define ACP_PGFSM_CNTL_POWER_ON_MASK          0x1
 #define ACP_PGFSM_STATUS_MASK                 0x3
 #define ACP_SOFT_RESET_SOFTRESET_AUDDONE_MASK 0x10001
-#define ACP_WOV_MISC_CTRL_MASK                0x10
+#define ACP_WOV_GAIN_CONTROL                  0x18
+#define ACP_WOV_GAIN_CONTROL_SHIFT            0x3
+#define ACP_WOV_PDM_GAIN                      0x2
 
 #define ACP_COUNTER               20000
+#define ACP_DMA_PAGE_SIZE         4096
 #define ACP_MEM_WINDOW_START      0x4000000
 #define ACP_PAGE_SIZE_4K_ENABLE   0x2
 #define ACP_PDM_DECIMATION_FACTOR 0x2
@@ -74,15 +77,20 @@ class AMDMicrophoneDevice : public IOAudioDevice {
     IOMemoryMap* baseAddrMap;
     IOVirtualAddress baseAddr;
     IOBufferMemoryDescriptor* dmaDescriptor;
+    UInt64 dmaStartByteCount = 0;
+    UInt64 lastPeriodCount = 0;
+    bool dmaPrepared = false;
 
     UInt32 readl(UInt32 reg);
     void writel(UInt32 val, UInt32 reg);
 
     void configDMA();
+    void clearDMABuffer();
     void disableInterrupt();
     void enableClock();
     void enableInterrupt();
     UInt64 getByteCount();
+    UInt64 getRelativeByteCount();
     void initRingBuffer(UInt32 physAddr, UInt32 bufferSize, UInt32 watermarkSize);
     IOReturn powerOff();
     IOReturn powerOn();

--- a/AMDMicrophone/AMDMicrophoneEngine.cpp
+++ b/AMDMicrophone/AMDMicrophoneEngine.cpp
@@ -127,6 +127,7 @@ bool AMDMicrophoneEngine::initHardware(IOService* provider)
     initialSampleRate.fraction = 0;
     setSampleRate(&initialSampleRate);
     setNumSampleFramesPerBuffer(NUM_FRAMES);
+    setInputSampleOffset(PERIOD_FRAMES);
 
     if (!createControls())
         goto Done;
@@ -155,30 +156,77 @@ IOReturn AMDMicrophoneEngine::convertInputSamples(
     const IOAudioStreamFormat* streamFormat, IOAudioStream* audioStream
 )
 {
-    UInt32 numSamplesLeft;
     float* floatDestBuf;
     SInt32* inputBuf32;
     UInt32 firstSample = firstSampleFrame * streamFormat->fNumChannels;
 
     floatDestBuf = (float*)destBuf;
-    numSamplesLeft = numSampleFrames * streamFormat->fNumChannels;
-
     inputBuf32 = &(((SInt32*)sampleBuf)[firstSample]);
-    while (numSamplesLeft-- > 0)
-        *floatDestBuf++ = (float)*inputBuf32++ * volume / MAX_VOLUME / INT32_MAX;
+
+    while (numSampleFrames-- > 0) {
+        float sample;
+        float level;
+        float targetGain;
+
+        if (streamFormat->fNumChannels == 2) {
+            float left = (float)inputBuf32[0] / INT32_MAX;
+            float right = (float)inputBuf32[1] / INT32_MAX;
+
+            sample = (left + right) * 0.5f;
+            inputBuf32 += 2;
+        } else {
+            sample = (float)*inputBuf32++ / INT32_MAX;
+        }
+
+        sample *= (float)volume / MAX_VOLUME;
+
+        level = sample >= 0.0f ? sample : -sample;
+        expanderEnvelope = expanderEnvelope * 0.990f + level * 0.010f;
+        if (expanderEnvelope >= INPUT_EXPANDER_THRESHOLD) {
+            targetGain = 1.0f;
+        } else {
+            targetGain = INPUT_EXPANDER_FLOOR
+                + (1.0f - INPUT_EXPANDER_FLOOR) * expanderEnvelope / INPUT_EXPANDER_THRESHOLD;
+        }
+
+        if (targetGain > expanderGain)
+            expanderGain += (targetGain - expanderGain) * INPUT_EXPANDER_ATTACK;
+        else
+            expanderGain += (targetGain - expanderGain) * INPUT_EXPANDER_RELEASE;
+
+        sample *= expanderGain;
+        sample *= INPUT_SOFTWARE_GAIN;
+
+        if (startupFadeFrame < STARTUP_FADE_FRAMES) {
+            sample *= (float)startupFadeFrame / STARTUP_FADE_FRAMES;
+            startupFadeFrame++;
+        }
+
+        if (sample > 1.0f)
+            sample = 1.0f;
+        else if (sample < -1.0f)
+            sample = -1.0f;
+
+        for (UInt32 channel = 0; channel < streamFormat->fNumChannels; channel++)
+            *floatDestBuf++ = sample;
+    }
 
     return kIOReturnSuccess;
 }
 
 UInt32 AMDMicrophoneEngine::getCurrentSampleFrame()
 {
-    return (UInt32)audioDevice->getByteCount() / FRAME_SIZE;
+    return (UInt32)(audioDevice->getRelativeByteCount() % BUFFER_SIZE) / FRAME_SIZE;
 }
 
 IOReturn AMDMicrophoneEngine::performAudioEngineStart()
 {
     takeTimeStamp(false);
+    startupFadeFrame = 0;
+    expanderEnvelope = 0.0f;
+    expanderGain = INPUT_EXPANDER_FLOOR;
 
+    audioDevice->clearDMABuffer();
     audioDevice->initRingBuffer(ACP_MEM_WINDOW_START, BUFFER_SIZE, PERIOD_SIZE);
     audioDevice->writel(0x0, ACP_WOV_PDM_NO_OF_CHANNELS);
     audioDevice->writel(ACP_PDM_DECIMATION_FACTOR, ACP_WOV_PDM_DECIMATION_FACTOR);

--- a/AMDMicrophone/AMDMicrophoneEngine.hpp
+++ b/AMDMicrophone/AMDMicrophoneEngine.hpp
@@ -19,8 +19,15 @@
 #define SAMPLE_DEPTH 32
 #define SAMPLE_WIDTH 32
 #define FRAME_SIZE   (NUM_CHANNELS * SAMPLE_WIDTH / 8)
+#define PERIOD_FRAMES (PERIOD_SIZE / FRAME_SIZE)
 #define NUM_FRAMES   (BUFFER_SIZE / FRAME_SIZE)
 #define MAX_VOLUME   100
+#define INPUT_SOFTWARE_GAIN 3.0f
+#define INPUT_EXPANDER_THRESHOLD 0.018f
+#define INPUT_EXPANDER_FLOOR 0.18f
+#define INPUT_EXPANDER_ATTACK 0.05f
+#define INPUT_EXPANDER_RELEASE 0.001f
+#define STARTUP_FADE_FRAMES (SAMPLE_RATE / 2)
 
 class AMDMicrophoneDevice;
 
@@ -29,6 +36,9 @@ class AMDMicrophoneEngine : public IOAudioEngine {
 
     AMDMicrophoneDevice* audioDevice;
     UInt32 volume = MAX_VOLUME;
+    UInt32 startupFadeFrame = STARTUP_FADE_FRAMES;
+    float expanderEnvelope = 0.0f;
+    float expanderGain = 1.0f;
 
     bool createControls();
     IOAudioStream* createNewAudioStream(


### PR DESCRIPTION
Hi!

I've been working on getting the `AMDMicrophone` kext running smoothly on my RedmiBook 16 (Ryzen 4500U) for newer macOS versions (Sequoia/Tahoe). I was getting a lot of static noise, robot-like distortion, and a loud "pop" sound when the mic started. This PR fixes those issues.

**Here’s what changed:**
- **DMA Fixes (Fixes static noise):** Forced DMA PTE mapping to strictly use 4KB pages to prevent hardware misreads. Also added `prepare()`/`complete()` for the DMA descriptor and zero-filled the buffer before starting.
- **Buffer Tracking:** Switched to a relative byte count for ring buffer tracking and added an input sample offset to improve CoreAudio stability.
- **Audio Quality:** Updated the dual-mono logic to properly average both channels `(left + right) * 0.5f` to prevent micro-glitches and distortion.
- **Natural Noise Gate:** Replaced the hard noise gate with a smooth downward expander so it doesn't abruptly cut off soft speech.
- **Startup Fade-in:** Added a 0.5s fade-in to completely eliminate the annoying "click" sound when the mic turns on.

I've been testing this daily and the mic sounds super clean and stable now. Let me know if anything needs tweaking. Thanks for the awesome project! 🚀
